### PR TITLE
Update SCSS Compiler to work with later versions of scssphp/scssphp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "civicrm/composer-compile-plugin": "~0.9 || ~1.0",
         "symfony/filesystem": "~2.8 || ~3.4 || ~4.0 || ~5.0",
-        "scssphp/scssphp": "~1.2",
+        "scssphp/scssphp": "~1.5",
         "padaliyajay/php-autoprefixer": "~1.2",
         "tubalmartin/cssmin": "^4.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae55cd77803c8d008816142aa485b5b0",
+    "content-hash": "88d8938d11d3a8b3dc5cfafc25ab4e80",
     "packages": [
         {
             "name": "civicrm/composer-compile-plugin",
-            "version": "v0.9",
+            "version": "v0.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/civicrm/composer-compile-plugin.git",
-                "reference": "ad3dda7edecbc83d460d4839154e74c67b3eb146"
+                "reference": "af9686c4511ad4d2dde3c32aafa4637579e1085d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/civicrm/composer-compile-plugin/zipball/ad3dda7edecbc83d460d4839154e74c67b3eb146",
-                "reference": "ad3dda7edecbc83d460d4839154e74c67b3eb146",
+                "url": "https://api.github.com/repos/civicrm/composer-compile-plugin/zipball/af9686c4511ad4d2dde3c32aafa4637579e1085d",
+                "reference": "af9686c4511ad4d2dde3c32aafa4637579e1085d",
                 "shasum": ""
             },
             "require": {
@@ -49,7 +49,11 @@
                 }
             ],
             "description": "Define a 'compile' event for all packages in the dependency-graph",
-            "time": "2020-09-26T08:20:55+00:00"
+            "support": {
+                "issues": "https://github.com/civicrm/composer-compile-plugin/issues",
+                "source": "https://github.com/civicrm/composer-compile-plugin/tree/v0.15"
+            },
+            "time": "2021-01-13T05:12:30+00:00"
         },
         {
             "name": "padaliyajay/php-autoprefixer",
@@ -84,6 +88,10 @@
                 }
             ],
             "description": "CSS Autoprefixer written in pure PHP.",
+            "support": {
+                "issues": "https://github.com/padaliyajay/php-autoprefixer/issues",
+                "source": "https://github.com/padaliyajay/php-autoprefixer/tree/1.3"
+            },
             "time": "2019-11-26T09:55:37+00:00"
         },
         {
@@ -129,20 +137,24 @@
                 "parser",
                 "stylesheet"
             ],
+            "support": {
+                "issues": "https://github.com/sabberworm/PHP-CSS-Parser/issues",
+                "source": "https://github.com/sabberworm/PHP-CSS-Parser/tree/8.3.1"
+            },
             "time": "2020-06-01T09:10:00+00:00"
         },
         {
             "name": "scssphp/scssphp",
-            "version": "1.2.1",
+            "version": "v1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/scssphp/scssphp.git",
-                "reference": "a05ea68160b7286ebbfd6e5fd7ae9e1a946ad6e1"
+                "reference": "d90ea7c479151f6254a6655446fd3425e59e22e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/scssphp/scssphp/zipball/a05ea68160b7286ebbfd6e5fd7ae9e1a946ad6e1",
-                "reference": "a05ea68160b7286ebbfd6e5fd7ae9e1a946ad6e1",
+                "url": "https://api.github.com/repos/scssphp/scssphp/zipball/d90ea7c479151f6254a6655446fd3425e59e22e8",
+                "reference": "d90ea7c479151f6254a6655446fd3425e59e22e8",
                 "shasum": ""
             },
             "require": {
@@ -151,11 +163,17 @@
                 "php": ">=5.6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.3",
-                "sass/sass-spec": "2020.08.10",
+                "bamarni/composer-bin-plugin": "^1.4",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.3 || ^9.4",
+                "sass/sass-spec": "*",
                 "squizlabs/php_codesniffer": "~3.5",
+                "symfony/phpunit-bridge": "^5.1",
                 "twbs/bootstrap": "~4.3",
                 "zurb/foundation": "~6.5"
+            },
+            "suggest": {
+                "ext-iconv": "Can be used as fallback when ext-mbstring is not available",
+                "ext-mbstring": "For best performance, mbstring should be installed as it is faster than ext-iconv"
             },
             "bin": [
                 "bin/pscss"
@@ -191,20 +209,24 @@
                 "scss",
                 "stylesheet"
             ],
-            "time": "2020-09-07T21:15:42+00:00"
+            "support": {
+                "issues": "https://github.com/scssphp/scssphp/issues",
+                "source": "https://github.com/scssphp/scssphp/tree/v1.5.0"
+            },
+            "time": "2021-05-14T12:18:56+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.4.45",
+            "version": "v3.4.47",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "495646f13d051cc5a8f77a68b68313dc854080aa"
+                "reference": "e58d7841cddfed6e846829040dca2cca0ebbbbb3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/495646f13d051cc5a8f77a68b68313dc854080aa",
-                "reference": "495646f13d051cc5a8f77a68b68313dc854080aa",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e58d7841cddfed6e846829040dca2cca0ebbbbb3",
+                "reference": "e58d7841cddfed6e846829040dca2cca0ebbbbb3",
                 "shasum": ""
             },
             "require": {
@@ -212,11 +234,6 @@
                 "symfony/polyfill-ctype": "~1.8"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Filesystem\\": ""
@@ -241,6 +258,9 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v3.4.47"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -255,24 +275,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-02T16:06:40+00:00"
+            "time": "2020-10-24T10:57:07+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.18.1",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454"
+                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/1c302646f6efc070cd46856e600e5e0684d6b454",
-                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
+                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
@@ -280,7 +300,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.22-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -317,6 +337,9 @@
                 "polyfill",
                 "portable"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.1"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -331,7 +354,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "time": "2021-01-07T16:49:33+00:00"
         },
         {
             "name": "totten/lurkerlite",
@@ -391,6 +414,9 @@
                 "resource",
                 "watching"
             ],
+            "support": {
+                "source": "https://github.com/totten/Lurker/tree/1.3.0"
+            },
             "time": "2020-09-01T10:01:01+00:00"
         },
         {
@@ -444,6 +470,10 @@
                 "minify",
                 "yui"
             ],
+            "support": {
+                "issues": "https://github.com/tubalmartin/YUI-CSS-compressor-PHP-port/issues",
+                "source": "https://github.com/tubalmartin/YUI-CSS-compressor-PHP-port"
+            },
             "time": "2018-01-15T15:26:51+00:00"
         }
     ],
@@ -458,5 +488,5 @@
     "platform-overrides": {
         "php": "7.1"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/src/ScssCompiler.php
+++ b/src/ScssCompiler.php
@@ -42,7 +42,7 @@ class ScssCompiler extends \ScssPhp\ScssPhp\Compiler {
       }
     }
 
-    return parent::findImport($url);
+    return parent::findImport($url, $currentDir);
   }
 
   public function addImportPrefix(string $prefix, string $path) {

--- a/src/ScssCompiler.php
+++ b/src/ScssCompiler.php
@@ -14,7 +14,7 @@ class ScssCompiler extends \ScssPhp\ScssPhp\Compiler {
    *
    * @return string|null
    */
-  public function findImport($url) {
+  public function findImport($url, $currentDir = NULL) {
     $hasExtension = preg_match('/[.]s?css$/', $url);
     $pickFile = function($path) use ($hasExtension) {
       $dir = dirname($path);


### PR DESCRIPTION
ping @mikeymjco

```
> @php -r "require_once '.../vendor/autoload.php'; Civi\CompilePlugin\TaskTransfer::import(); \CCL::copy('../../bower_components/select2/select2-bootstrap.css', 'extern/select2/select2-bootstrap.scss');"
> @php -r "require_once '.../vendor/autoload.php'; Civi\CompilePlugin\TaskTransfer::import(); \CCL\Tasks::scss($GLOBALS[ COMPOSER_COMPILE_TASK ]);"
PHP Warning:  Use of undefined constant COMPOSER_COMPILE_TASK - assumed 'COMPOSER_COMPILE_TASK' (this will throw an Error in a future version of PHP) in Command line code on line 1
PHP Warning:  Declaration of CCL\ScssCompiler::findImport($url) should be compatible with ScssPhp\ScssPhp\Compiler::findImport($url, $currentDir = NULL) in ...\vendor\civicrm\composer-compile-lib\src\ScssCompiler.php on line 17
PHP Fatal error:  Uncaught ScssPhp\ScssPhp\Exception\CompilerException: `mixins/hide-text` file not found for @import: extern/bootstrap3/assets/stylesheets\bootstrap/_mixins.scss on line 5, at column 1
Call Stack:
0 import extern/bootstrap3/assets/stylesheets\bootstrap/_mixins.scss extern/bootstrap3/assets/stylesheets/_bootstrap.scss on line 9
1 import extern/bootstrap3/assets/stylesheets/_bootstrap.scss (unknown file) on line 3 in ...\vendor\scssphp\scssphp\src\Compiler.php:5960
Stack trace:
0 ...\vendor\scssphp\scssphp\src\Compiler.php(5733): ScssPhp\ScssPhp\Compiler->error('`mixins/hide-te...')
1 ...\vendor\civicrm\composer-compile-lib\src\ScssCompiler.php(45): ScssPhp\ScssPhp\Compiler->findImport('mixins/hide-tex...')
2 ...\vendor\scssphp\scssphp\src\Compiler.php(2644): CCL\ScssCompiler->findImport('mixins/hide-tex...', 'extern/bootstra...')
3  in ...\vendor\scssphp\scssphp\src\Compiler.php on line 5960
Script @php -r "require_once '.../vendor/autoload.php'; Civi\CompilePlugin\TaskTransfer::import(); \CCL\Tasks::scss($GLOBALS[ COMPOSER_COMPILE_TASK ]);" handling the shell-runner event returned with error code 255

Warning: Use of undefined constant COMPOSER_COMPILE_TASK - assumed 'COMPOSER_COMPILE_TASK' (this will throw an Error in a future version of PHP) in Command line code on line 1

Warning: Declaration of CCL\ScssCompiler::findImport($url) should be compatible with ScssPhp\ScssPhp\Compiler::findImport($url, $currentDir = NULL) in ...\vendor\civicrm\composer-compile-lib\src\ScssCompiler.php on line 17

Fatal error: Uncaught ScssPhp\ScssPhp\Exception\CompilerException: `mixins/hide-text` file not found for @import: extern/bootstrap3/assets/stylesheets\bootstrap/_mixins.scss on line 5, at column 1
Call Stack:
0 import extern/bootstrap3/assets/stylesheets\bootstrap/_mixins.scss extern/bootstrap3/assets/stylesheets/_bootstrap.scss on line 9
1 import extern/bootstrap3/assets/stylesheets/_bootstrap.scss (unknown file) on line 3 in ...\vendor\scssphp\scssphp\src\Compiler.php:5960
Stack trace:
0 ...\vendor\scssphp\scssphp\src\Compiler.php(5733): ScssPhp\ScssPhp\Compiler->error('`mixins/hide-te...')
1 ...\vendor\civicrm\composer-compile-lib\src\ScssCompiler.php(45): ScssPhp\ScssPhp\Compiler->findImport('mixins/hide-tex...')
2 ...\vendor\scssphp\scssphp\src\Compiler.php(2644): CCL\ScssCompiler->findImport('mixins/hide-tex...', 'extern/bootstra...')
3  in ...\vendor\scssphp\scssphp\src\Compiler.php on line 5960
Subcommand @composer compile  returned with error code 255

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```