### PR TITLE
dev/drupal#176 - Allow symfony 6 / drupal 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require": {
         "civicrm/composer-compile-plugin": "~0.19 || ~1.0",
-        "symfony/filesystem": "~2.8 || ~3.4 || ~4.0 || ~5.0",
+        "symfony/filesystem": "~2.8 || ~3.4 || ~4.0 || ~5.0 || ~6.0",
         "scssphp/scssphp": "^1.8.1",
         "padaliyajay/php-autoprefixer": "~1.2",
         "tubalmartin/cssmin": "^4.1"


### PR DESCRIPTION
I don't see anything jump out in symfony itself: https://github.com/symfony/filesystem/compare/5.4...6.1

There is this comment here but I haven't seen anything go wrong using with drupal 10: https://github.com/civicrm/composer-compile-lib/blob/8bd52f0d2ba97eaa83853c3cfc37841376f5b903/src/StubsTpl.php#L59-L60
