### PR TITLE
Allow "Symfony Filesystem" 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require": {
         "civicrm/composer-compile-plugin": "~0.19 || ~1.0",
-        "symfony/filesystem": "~2.8 || ~3.4 || ~4.0 || ~5.0 || ~6.0",
+        "symfony/filesystem": "~2.8 || ~3.4 || ~4.0 || ~5.0 || ~6.0 || ~7.0",
         "scssphp/scssphp": "^1.8.1",
         "padaliyajay/php-autoprefixer": "~1.2",
         "tubalmartin/cssmin": "^4.1"


### PR DESCRIPTION
Drupal 11 requires Symfony 7.

Update composer.json to allow Symfony 7