### PR TITLE
composer.json - Bump PHP minimum to 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "config": {
         "platform": {
-            "php": "7.2"
+            "php": "7.4"
         },
         "allow-plugins": {
             "civicrm/composer-compile-plugin": true


### PR DESCRIPTION
Follow-up to #7 -- we don't need support 7.2 or 7.3 because:

* Current-stable CiviCRM requires 7.4+ (which is minimum for any distmaker-based deployments)
* The target-audience that sees this package is mostly composer-based -- and composer is clever enough to give them prior revisions.

cc @demeritcowboy 