### PR TITLE
allow Symfony 8 for Drupal 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require": {
         "civicrm/composer-compile-plugin": "~0.19 || ~1.0",
-        "symfony/filesystem": "~2.8 || ~3.4 || ~4.0 || ~5.0 || ~6.0 || ~7.0",
+        "symfony/filesystem": "~2.8 || ~3.4 || ~4.0 || ~5.0 || ~6.0 || ~7.0 || ~8.0",
         "scssphp/scssphp": "^1.8.1",
         "padaliyajay/php-autoprefixer": "~1.2",
         "tubalmartin/cssmin": "^4.1"


### PR DESCRIPTION
Allows use of Symfony 8 required for Drupal 12.